### PR TITLE
Updating to 12.2.1 wkhtmltopdf; using .deb install flow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,10 @@ RUN apt-get update
 RUN apt-get upgrade -y
 
 # Download and install wkhtmltopdf
-RUN apt-get install -y build-essential xorg libssl-dev libxrender-dev wget
-RUN wget http://wkhtmltopdf.googlecode.com/files/wkhtmltopdf-0.11.0_rc1-static-amd64.tar.bz2
-RUN tar xvjf wkhtmltopdf-0.11.0_rc1-static-amd64.tar.bz2
-RUN install wkhtmltopdf-amd64 /usr/bin/wkhtmltopdf
-
-ENTRYPOINT ["/usr/bin/wkhtmltopdf"]
+RUN apt-get install -y build-essential xorg libssl-dev libxrender-dev wget gdebi
+RUN wget http://downloads.sourceforge.net/project/wkhtmltopdf/0.12.2.1/wkhtmltox-0.12.2.1_linux-trusty-amd64.deb
+RUN gdebi --n wkhtmltox-0.12.2.1_linux-trusty-amd64.deb
+ENTRYPOINT ["wkhtmltopdf"]
 
 # Show the extended help
 CMD ["-h"]


### PR DESCRIPTION
I needed a docker image with the updated 12.2.1 wkhtmltopdf, hence the Pull Request.

There may be a better way to set things up, but this Dockerfile gives me a perfectly operational image, hence I am happy with it.
