### PR TITLE
Update url of wkhtmltopdf .deb package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get upgrade -y
 
 # Download and install wkhtmltopdf
 RUN apt-get install -y build-essential xorg libssl-dev libxrender-dev wget gdebi
-RUN wget http://downloads.sourceforge.net/project/wkhtmltopdf/0.12.2.1/wkhtmltox-0.12.2.1_linux-trusty-amd64.deb
+RUN wget http://download.gna.org/wkhtmltopdf/0.12/0.12.2.1/wkhtmltox-0.12.2.1_linux-trusty-amd64.deb
 RUN gdebi --n wkhtmltox-0.12.2.1_linux-trusty-amd64.deb
 ENTRYPOINT ["wkhtmltopdf"]
 


### PR DESCRIPTION
(project change from sourceforce to gna.org)

Related to this issue https://github.com/openlabs/docker-wkhtmltopdf/issues/5
